### PR TITLE
[feature] 可运行实例

### DIFF
--- a/core/okx/kline.py
+++ b/core/okx/kline.py
@@ -2,12 +2,14 @@ import requests
 import pandas as pd
 import time
 from datetime import datetime
+from core.okx.retry import retry
 
 BASE_URL = "https://www.okx.com/api/v5/market/history-candles"
 BAR = "5m"
 LIMIT = 300  # OKX 每次最多 100 条
 
 
+@retry()
 def fetch_candles(coin: str, after=""):
     """从 OKX 获取一分钟 K 线数据"""
     params = {

--- a/main.py
+++ b/main.py
@@ -27,7 +27,8 @@ class Machine:
     def avail_balance(self) -> float:
         bl = self.api.get_account_usdt() * 1.0 / len(self.target_coins)
         a = self.api.get_account_balance("USDT")
-        return min(a, bl)
+        # 预留100刀，防止交易失败
+        return min(a - 100, bl)
 
     def short(self, coin: str):
         [long, short] = self.api.get_position_size_long_and_short(


### PR DESCRIPTION
## Sourcery 总结

为获取 OKX K 线数据添加重试机制，并在交易逻辑中保留余额缓冲区

改进点：
- 为 `fetch_candles` 添加重试装饰器，以实现自动请求重试
- 在 `avail_balance` 中保留 $100，以避免交易失败

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add retry mechanism to OKX K-line data fetching and reserve a balance buffer in trading logic

Enhancements:
- Add retry decorator to fetch_candles for automatic request retries
- Reserve $100 in avail_balance to avoid trade failures

</details>